### PR TITLE
added rancher build options to the cli

### DIFF
--- a/local/api.go
+++ b/local/api.go
@@ -11,6 +11,7 @@ import (
 	handlers_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
 	handlers_local "github.com/wunderkraut/radi-handlers/local"
 	handlers_null "github.com/wunderkraut/radi-handlers/null"
+	handlers_rancher "github.com/wunderkraut/radi-handlers/rancher"
 	handlers_upcloud "github.com/wunderkraut/radi-handlers/upcloud"
 )
 
@@ -94,6 +95,9 @@ func MakeLocalAPI(settings handlers_local.LocalAPISettings) (api_api.API, error)
 				case "upcloud":
 					log.Debug("LocalAPI: Building UpCloud builder")
 					localApi.AddBuilder(api_builder.Builder(&handlers_upcloud.UpcloudBuilder{}))
+				case "rancher":
+					log.Debug("LocalAPI: Building Rancher builder")
+					localApi.AddBuilder(api_builder.Builder(&handlers_rancher.RancherBuilder{}))
 				default:
 					buildErr = errors.New("Unrecognized builder " + builderSetting.Type)
 					log.WithError(buildErr).Error("Could not build " + builderSetting.Type)

--- a/main/discover.go
+++ b/main/discover.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	RADI_PROJECT_CONF_FOLDER = ".radi" // If the project has existing setitngs, they will be in this subfolder, somewhere up the file tree.
-	RADI_USER_CONF_SUBPATH   = "radi"  // If the user has user-scope config, they will be in this subfolder
+	RADI_PROJECT_CONF_FOLDER      = ".radi"        // If the project has existing setitngs, they will be in this subfolder, somewhere up the file tree.
+	RADI_USER_CONF_SUBPATH        = "radi"         // If the user has user-scope config, they will be in this subfolder
 	RADI_ENVIRONMENT_CONF_SUBPATH = "environments" // a subpath in .radi for per environment settings
 )
 


### PR DESCRIPTION
This patch enables use of the rancher handler by adding "rancher" to any project.yml implementations set.

Also gofmt formatting was applied.