### PR TITLE
Api refactor

### DIFF
--- a/local/api.go
+++ b/local/api.go
@@ -8,112 +8,50 @@ import (
 	api_api "github.com/wunderkraut/radi-api/api"
 	api_builder "github.com/wunderkraut/radi-api/builder"
 	api_config "github.com/wunderkraut/radi-api/operation/config"
-	handlers_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
 	handlers_local "github.com/wunderkraut/radi-handlers/local"
-	handlers_null "github.com/wunderkraut/radi-handlers/null"
-	handlers_rancher "github.com/wunderkraut/radi-handlers/rancher"
-	handlers_upcloud "github.com/wunderkraut/radi-handlers/upcloud"
 )
 
 /**
- * Build a local API, by scanning for project settings based on the
- * path.  First a number of "conf" folders are determinged, and these
- * are used to build the localAPI.
+ * Make a local API
+ *
+ * First we check to see if we have a local project.  If not then
+ * we return a minimal "build a project" api, which will give operations
+ * but little real functionality outside of initializing a project
+ *
+ * If we have a project then we follow the following steps:
+ *   1. build a bootstrap API, which is used to load configuraion
+ *   2. Use the configuration from the boostrap to build a real
+ *      API for the actual project config.
+ *
+ * This sequence is necessary to bypass the chicken-egg dilemna where
+ * we need an API to get project settings, but we need project settings
+ * to decide what API to build.  The Boostrap API does have some weight,
+ * but not much to worry about (perhaps a couple of files are opened 2x)
+ *
  */
-
-// Construct a LocalAPI by checking some paths for the current user.
 func MakeLocalAPI(settings handlers_local.LocalAPISettings) (api_api.API, error) {
-	var err error
 
-	/**
-	 * We have local settings, from which we can build our API
-	 *
-	 * We will build it using a BuilderAPI, and adding the local
-	 * Builder, which will be used at a minimum for a ConfigWrapper,
-	 * to determine how to build the rest of the project.
-	 * The reason for this preliminary step is a chicken and egg dilemna
-	 * where we need an api to get project settings, but we need
-	 * project settings to decide how to build an API.
-	 *
-	 * The resulting API will be used to bootstrap the app.
-	 */
-	log.Debug("CLI:LocalAPI: Building bootsrap API")
-	bootstrapApi := api_builder.BuilderAPI{}
-	bootstrapApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
-
-	/**
-	 * If we have discovered that there is no local project folder,
-	 * then we will enable a minimum API, which can be used to create
-	 * a local folder
-	 */
 	if settings.ProjectDoesntExist {
 
-		// allow local project operations, which could be used to build a project
-		bootstrapApi.ActivateBuilder("local", *api_builder.New_Implementations([]string{"project"}), nil)
-
-		// Use null wrappers for those handlers that we don't have (to play safe)
-		bootstrapApi.AddBuilder(handlers_null.New_NullBuilder())
-		bootstrapApi.ActivateBuilder("null", *api_builder.New_Implementations([]string{"config", "seting", "command"}), nil)
-
-		err = errors.New("No project found.")
-
-		return api_api.API(&bootstrapApi), err
+		localAPI, _ := MakeLocalAPI_NoProject(settings)
+		return localAPI, errors.New("No project found.")
 
 	} else {
-		/**
-		 * The automated build is complex enough that it deserves
-		 * it's own method
-		 */
 
-		// build at least the config operations, which we will need for a config wrapper
-		bootstrapApi.ActivateBuilder("local", *api_builder.New_Implementations([]string{"config", "setting", "security"}), nil)
+		// build an API with at least the config operations, which we will need for a config wrapper
+		log.Debug("Local:API:: Building bootsrap API")
+		bootstrapApi := api_builder.BuilderAPI{}
+		bootstrapApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
+		bootstrapApi.ActivateBuilder("local", *api_builder.New_Implementations([]string{"config"}), nil)
 
 		// Now use the config operations to determine what builds are needed
 		bootstrapOps := bootstrapApi.Operations()
 		bootstrapConfigWrapper := api_config.New_SimpleConfigWrapper(&bootstrapOps)
 
-		// Use the builderConfigWrapper to list build components
-		builderConfigWrapper := handlers_configwrapper.New_BuilderComponentsConfigWrapperYaml(bootstrapConfigWrapper)
-		builderList := builderConfigWrapper.List()
+		localAPI, err := MakeLocalAPI_LocalSecure(settings, bootstrapConfigWrapper)
+		// we could also use MakeLocalAPI_Local(settings, bootstrapConfigWrapper)
 
-		// this is our actual local API
-		log.Debug("CLI:LocalAPI: Building LocalAPI [secured]")
-		localApi := api_builder.SecureBuilderAPI{}
-
-		built := map[string]bool{}
-
-		for _, key := range builderList {
-			builderSetting, _ := builderConfigWrapper.Get(key)
-			var buildErr error
-
-			if _, checked := built[builderSetting.Type]; !checked {
-				built[builderSetting.Type] = true
-				switch builderSetting.Type {
-				case "local":
-					log.Debug("LocalAPI: Building Local builder")
-					localApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
-				case "upcloud":
-					log.Debug("LocalAPI: Building UpCloud builder")
-					localApi.AddBuilder(api_builder.Builder(&handlers_upcloud.UpcloudBuilder{}))
-				case "rancher":
-					log.Debug("LocalAPI: Building Rancher builder")
-					localApi.AddBuilder(api_builder.Builder(&handlers_rancher.RancherBuilder{}))
-				default:
-					buildErr = errors.New("Unrecognized builder " + builderSetting.Type)
-					log.WithError(buildErr).Error("Could not build " + builderSetting.Type)
-					built[builderSetting.Type] = false
-				}
-			}
-
-			if success, checked := built[builderSetting.Type]; success && checked {
-				log.WithFields(log.Fields{"type": builderSetting.Type, "implementations": builderSetting.Implementations.Order(), "key": key}).Debug("Activate builder from settings")
-				localApi.ActivateBuilder(builderSetting.Type, builderSetting.Implementations, builderSetting.SettingsProvider)
-			} else {
-				log.WithError(err).WithFields(log.Fields{"builder": builderSetting.Type}).Error("Unknown builder referenced in local project")
-			}
-		}
-
-		return api_api.API(&localApi), err
+		return localAPI, err
 	}
 
 }

--- a/local/api_localsecure.go
+++ b/local/api_localsecure.go
@@ -1,0 +1,77 @@
+package local
+
+import (
+	"errors"
+
+	log "github.com/Sirupsen/logrus"
+
+	api_api "github.com/wunderkraut/radi-api/api"
+	api_builder "github.com/wunderkraut/radi-api/builder"
+	api_config "github.com/wunderkraut/radi-api/operation/config"
+	handlers_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
+	handlers_local "github.com/wunderkraut/radi-handlers/local"
+	handlers_null "github.com/wunderkraut/radi-handlers/null"
+	handlers_rancher "github.com/wunderkraut/radi-handlers/rancher"
+	handlers_upcloud "github.com/wunderkraut/radi-handlers/upcloud"
+)
+
+/**
+ * Build a local API, by scanning for project settings based on the
+ * path.  First a number of "conf" folders are determinged, and these
+ * are used to build the localAPI.
+ */
+
+// Construct a LocalAPI by checking some paths for the current user.
+func MakeLocalAPI_LocalSecure(settings handlers_local.LocalAPISettings, configWrapper api_config.ConfigWrapper) (api_api.API, error) {
+	var err error
+
+	// this is our actual local API
+	log.Debug("CLI:LocalAPI: Building LocalAPI [secured]")
+	localApi := api_builder.SecureBuilderAPI{}
+
+	// Use the builderConfigWrapper to list build components
+	log.Debug("CLI:LocalAPI: Building LocalAPI: Building builder configwrapper")
+	builderConfigWrapper := handlers_configwrapper.New_BuilderComponentsConfigWrapperYaml(configWrapper)
+	builderList := builderConfigWrapper.List()
+	log.WithFields(log.Fields{"list": builderList}).Debug("CLI:LocalAPI: Building LocalAPI: Built builder configwrapper")
+
+	built := map[string]bool{}
+
+	for _, key := range builderList {
+		builderSetting, _ := builderConfigWrapper.Get(key)
+		var buildErr error
+
+		if _, checked := built[builderSetting.Type]; !checked {
+			log.WithFields(log.Fields{"builder": builderSetting.Type}).Debug("CLI:LocalAPI: Building LocalAPI : AddingBuilder")
+			built[builderSetting.Type] = true
+			switch builderSetting.Type {
+			case "null":
+				log.Debug("LocalAPI: Building Null builder")
+				localApi.AddBuilder(handlers_null.New_NullBuilder())
+			case "local":
+				log.Debug("LocalAPI: Building Local builder")
+				localApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
+			case "upcloud":
+				log.Debug("LocalAPI: Building UpCloud builder")
+				localApi.AddBuilder(api_builder.Builder(&handlers_upcloud.UpcloudBuilder{}))
+			case "rancher":
+				log.Debug("LocalAPI: Building Rancher builder")
+				localApi.AddBuilder(api_builder.Builder(&handlers_rancher.RancherBuilder{}))
+			default:
+				buildErr = errors.New("Unrecognized builder " + builderSetting.Type)
+				log.WithError(buildErr).Error("Could not build " + builderSetting.Type)
+				built[builderSetting.Type] = false
+			}
+		}
+
+		if success, checked := built[builderSetting.Type]; success && checked {
+			log.WithFields(log.Fields{"type": builderSetting.Type, "implementations": builderSetting.Implementations.Order(), "key": key}).Debug("Activate builder from settings")
+			localApi.ActivateBuilder(builderSetting.Type, builderSetting.Implementations, builderSetting.SettingsProvider)
+		} else {
+			log.WithError(err).WithFields(log.Fields{"builder": builderSetting.Type}).Error("Unknown builder referenced in local project")
+		}
+	}
+
+	return api_api.API(&localApi), err
+
+}

--- a/local/api_noproject.go
+++ b/local/api_noproject.go
@@ -1,0 +1,34 @@
+package local
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	api_api "github.com/wunderkraut/radi-api/api"
+	api_builder "github.com/wunderkraut/radi-api/builder"
+	handlers_local "github.com/wunderkraut/radi-handlers/local"
+	handlers_null "github.com/wunderkraut/radi-handlers/null"
+)
+
+/**
+ * If we have discovered that there is no local project folder,
+ * then we will enable a minimum API, which can be used to create
+ * a local folder
+ *
+ * The resulting API will be used to bootstrap the app.
+ */
+
+// Construct a LocalAPI with without expecting any local configuration
+func MakeLocalAPI_NoProject(settings handlers_local.LocalAPISettings) (api_api.API, error) {
+	log.Debug("Local:API:: Building No-Project API")
+	bootstrapApi := api_builder.BuilderAPI{}
+	bootstrapApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
+
+	// allow local project operations, which could be used to build a project
+	bootstrapApi.ActivateBuilder("local", *api_builder.New_Implementations([]string{"project"}), nil)
+
+	// Use null wrappers for those handlers that we don't have (to play safe)
+	bootstrapApi.AddBuilder(handlers_null.New_NullBuilder())
+	bootstrapApi.ActivateBuilder("null", *api_builder.New_Implementations([]string{"config", "seting", "command"}), nil)
+
+	return api_api.API(&bootstrapApi), nil
+}

--- a/main/operation.go
+++ b/main/operation.go
@@ -23,8 +23,10 @@ func AppApiOperations(app *cli.App, ops api_operation.Operations) error {
 			id := op.Id()
 			category := id[0:strings.Index(id, ".")]
 			alias := id[strings.Index(id, ".")+1:]
-			opWrapper := CliOperationWrapper{op: op}
 
+			log.WithFields(log.Fields{"id": id, "category": category, "alias": alias}).Debug("Cli: Adding Operation")
+
+			opWrapper := CliOperationWrapper{op: op}
 			cliComm := cli.Command{
 				Name:     op.Id(),
 				Aliases:  []string{alias},
@@ -35,7 +37,6 @@ func AppApiOperations(app *cli.App, ops api_operation.Operations) error {
 
 			cliComm.Flags = CliMakeFlagsFromProperties(op.Properties())
 
-			log.WithFields(log.Fields{"id": id}).Debug("Cli: Adding Operation")
 			app.Commands = append(app.Commands, &cliComm)
 		}
 	}
@@ -67,17 +68,14 @@ func (opWrapper *CliOperationWrapper) Exec(cliContext *cli.Context) error {
 
 	CliAssignPropertiesFromFlags(cliContext, &props)
 
-	var success bool
-	var errs []error = []error{}
-
 	result := opWrapper.op.Exec(&props)
 	<-result.Finished()
 
-	if !result.Success() {
-		errs := result.Errors()
-		if len(errs) == 0 {
-			errs = []error{errors.New("RadiCLI: Unknown error occured")}
-		}
+	success := result.Success() // bool
+	errs := result.Errors()     // []error
+
+	if !success && len(errs) == 0 {
+		errs = []error{errors.New("RadiCLI: Unknown error occured")}
 	}
 
 	// Create some meaningful output, by logging some of the properties
@@ -121,6 +119,10 @@ func (opWrapper *CliOperationWrapper) Exec(cliContext *cli.Context) error {
 		}
 
 		logger.Error("Error occured running operation")
-		return errs[len(errs)-1]
+		if len(errs) > 0 {
+			return errs[len(errs)-1]
+		} else {
+			return errors.New("Unknown error occured when trying to run an operation")
+		}
 	}
 }

--- a/main/property.go
+++ b/main/property.go
@@ -32,6 +32,7 @@ import (
 // Assign properties from flags back to properties
 func CliAssignPropertiesFromFlags(cliContext *cli.Context, props *api_operation.Properties) error {
 	for _, key := range props.Order() {
+
 		if !cliContext.IsSet(key) {
 			continue
 		}
@@ -93,7 +94,7 @@ func CliAssignPropertiesFromFlags(cliContext *cli.Context, props *api_operation.
 					}
 				}
 			default:
-				log.WithFields(log.Fields{"id": prop.Id(), "property": prop, "flag": cliContext.Generic(key)}).Debug("Unhandled property type for operation")
+				log.WithFields(log.Fields{"id": prop.Id(), "property": prop, "flag": cliContext.Generic(key)}).Debug("CLI does not handle any flags for property type")
 			}
 
 		}
@@ -168,7 +169,7 @@ func CliMakeFlagsFromProperties(props api_operation.Properties) []cli.Flag {
 				}))
 
 			default:
-				log.WithFields(log.Fields{"id": prop.Id(), "property": prop}).Debug("Unhandled property type for operation")
+				log.WithFields(log.Fields{"id": prop.Id(), "property": prop}).Debug("CLI does not yet handle property type for operation")
 
 				/**
 				 * originally we were wrapping these unhandled argument types


### PR DESCRIPTION
This patch updates the CLI for the incoming API refactor, which breaks API https://github.com/wunderkraut/radi-api/pull/3

Also in this patch is a splitting of the building of the LocalAPI, which makes it easier to reuse if forked.
