### PR TITLE
Fix for vendored libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
-.PHONY: cli-build build install clean
+.PHONY: build local get-deps fmt binary install clean
 
 MAKE_SCRIPT="./build/make.sh"
 
 default: all
 
-all: clean getdeps fmt build install
+all: build
+
+build: getdeps fmt binary install
+
+local: clean getdeps fmt binary install
+
+
 
 fmt:
 	${MAKE_SCRIPT} fmt
 
-build:
+binary:
 	${MAKE_SCRIPT} binary
 
 getdeps:

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ docker run --rm -ti \
 	-e "GOARCH=${GOARCH}" \
 	-w /usr/src/myapp \
 	golang:${GOVERSION} \
-	make clean getdeps build
+	make build
 
 echo " 
 

--- a/build/getdeps
+++ b/build/getdeps
@@ -1,23 +1,18 @@
 #!/bin/bash
 set -e
 
-echo "  --> updating go dependencies"
+echo "  --> retrieving go dependencies [recursively]"
 
 # Update all cli go dependencies
 
 #ORIGINALLY we were doing this go get -u ./cli/main
 
-DEPS="golang.org/x/net/context
-github.com/Sirupsen/logrus
+DEPS="github.com/Sirupsen/logrus
 gopkg.in/urfave/cli.v2
-gopkg.in/yaml.v2
-github.com/docker/libcompose
-github.com/Jalle19/upcloud-go-sdk/upcloud/
-github.com/Jalle19/upcloud-go-sdk/upcloud/client
-github.com/rancher/go-rancher/v2
-github.com/james-nesbitt/init-go
 github.com/wunderkraut/radi-api
-github.com/wunderkraut/radi-handlers"
+github.com/wunderkraut/radi-handlers
+github.com/wunderkraut/radi-handler-upcloud
+github.com/wunderkraut/radi-handler-rancher"
 
 for DEP in $DEPS; do
 	echo "     - ${DEP}"

--- a/local/api.go
+++ b/local/api.go
@@ -8,7 +8,7 @@ import (
 	api_api "github.com/wunderkraut/radi-api/api"
 	api_builder "github.com/wunderkraut/radi-api/builder"
 	api_config "github.com/wunderkraut/radi-api/operation/config"
-	handlers_local "github.com/wunderkraut/radi-handlers/local"
+	handler_local "github.com/wunderkraut/radi-handlers/local"
 )
 
 /**
@@ -29,7 +29,7 @@ import (
  * but not much to worry about (perhaps a couple of files are opened 2x)
  *
  */
-func MakeLocalAPI(settings handlers_local.LocalAPISettings) (api_api.API, error) {
+func MakeLocalAPI(settings handler_local.LocalAPISettings) (api_api.API, error) {
 
 	if settings.ProjectDoesntExist {
 
@@ -41,7 +41,7 @@ func MakeLocalAPI(settings handlers_local.LocalAPISettings) (api_api.API, error)
 		// build an API with at least the config operations, which we will need for a config wrapper
 		log.Debug("Local:API:: Building bootsrap API")
 		bootstrapApi := api_builder.BuilderAPI{}
-		bootstrapApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
+		bootstrapApi.AddBuilder(handler_local.New_LocalBuilder(settings))
 		bootstrapApi.ActivateBuilder("local", *api_builder.New_Implementations([]string{"config"}), nil)
 
 		// Now use the config operations to determine what builds are needed

--- a/local/api_localsecure.go
+++ b/local/api_localsecure.go
@@ -8,11 +8,11 @@ import (
 	api_api "github.com/wunderkraut/radi-api/api"
 	api_builder "github.com/wunderkraut/radi-api/builder"
 	api_config "github.com/wunderkraut/radi-api/operation/config"
-	handlers_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
-	handlers_local "github.com/wunderkraut/radi-handlers/local"
-	handlers_null "github.com/wunderkraut/radi-handlers/null"
-	handlers_rancher "github.com/wunderkraut/radi-handlers/rancher"
-	handlers_upcloud "github.com/wunderkraut/radi-handlers/upcloud"
+	handler_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
+	handler_local "github.com/wunderkraut/radi-handlers/local"
+	handler_null "github.com/wunderkraut/radi-handlers/null"
+	handler_rancher "github.com/wunderkraut/radi-handler-rancher"
+	handler_upcloud "github.com/wunderkraut/radi-handler-upcloud"
 )
 
 /**
@@ -22,7 +22,7 @@ import (
  */
 
 // Construct a LocalAPI by checking some paths for the current user.
-func MakeLocalAPI_LocalSecure(settings handlers_local.LocalAPISettings, configWrapper api_config.ConfigWrapper) (api_api.API, error) {
+func MakeLocalAPI_LocalSecure(settings handler_local.LocalAPISettings, configWrapper api_config.ConfigWrapper) (api_api.API, error) {
 	var err error
 
 	// this is our actual local API
@@ -31,7 +31,7 @@ func MakeLocalAPI_LocalSecure(settings handlers_local.LocalAPISettings, configWr
 
 	// Use the builderConfigWrapper to list build components
 	log.Debug("CLI:LocalAPI: Building LocalAPI: Building builder configwrapper")
-	builderConfigWrapper := handlers_configwrapper.New_BuilderComponentsConfigWrapperYaml(configWrapper)
+	builderConfigWrapper := handler_configwrapper.New_BuilderComponentsConfigWrapperYaml(configWrapper)
 	builderList := builderConfigWrapper.List()
 	log.WithFields(log.Fields{"list": builderList}).Debug("CLI:LocalAPI: Building LocalAPI: Built builder configwrapper")
 
@@ -47,16 +47,16 @@ func MakeLocalAPI_LocalSecure(settings handlers_local.LocalAPISettings, configWr
 			switch builderSetting.Type {
 			case "null":
 				log.Debug("LocalAPI: Building Null builder")
-				localApi.AddBuilder(handlers_null.New_NullBuilder())
+				localApi.AddBuilder(handler_null.New_NullBuilder())
 			case "local":
 				log.Debug("LocalAPI: Building Local builder")
-				localApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
+				localApi.AddBuilder(handler_local.New_LocalBuilder(settings))
 			case "upcloud":
 				log.Debug("LocalAPI: Building UpCloud builder")
-				localApi.AddBuilder(api_builder.Builder(&handlers_upcloud.UpcloudBuilder{}))
+				localApi.AddBuilder(api_builder.Builder(&handler_upcloud.UpcloudBuilder{}))
 			case "rancher":
 				log.Debug("LocalAPI: Building Rancher builder")
-				localApi.AddBuilder(api_builder.Builder(&handlers_rancher.RancherBuilder{}))
+				localApi.AddBuilder(api_builder.Builder(&handler_rancher.RancherBuilder{}))
 			default:
 				buildErr = errors.New("Unrecognized builder " + builderSetting.Type)
 				log.WithError(buildErr).Error("Could not build " + builderSetting.Type)

--- a/local/api_localsecure.go
+++ b/local/api_localsecure.go
@@ -8,11 +8,11 @@ import (
 	api_api "github.com/wunderkraut/radi-api/api"
 	api_builder "github.com/wunderkraut/radi-api/builder"
 	api_config "github.com/wunderkraut/radi-api/operation/config"
+	handler_rancher "github.com/wunderkraut/radi-handler-rancher"
+	handler_upcloud "github.com/wunderkraut/radi-handler-upcloud"
 	handler_configwrapper "github.com/wunderkraut/radi-handlers/configwrapper"
 	handler_local "github.com/wunderkraut/radi-handlers/local"
 	handler_null "github.com/wunderkraut/radi-handlers/null"
-	handler_rancher "github.com/wunderkraut/radi-handler-rancher"
-	handler_upcloud "github.com/wunderkraut/radi-handler-upcloud"
 )
 
 /**

--- a/local/api_noproject.go
+++ b/local/api_noproject.go
@@ -5,8 +5,8 @@ import (
 
 	api_api "github.com/wunderkraut/radi-api/api"
 	api_builder "github.com/wunderkraut/radi-api/builder"
-	handlers_local "github.com/wunderkraut/radi-handlers/local"
-	handlers_null "github.com/wunderkraut/radi-handlers/null"
+	handler_local "github.com/wunderkraut/radi-handlers/local"
+	handler_null "github.com/wunderkraut/radi-handlers/null"
 )
 
 /**
@@ -18,16 +18,16 @@ import (
  */
 
 // Construct a LocalAPI with without expecting any local configuration
-func MakeLocalAPI_NoProject(settings handlers_local.LocalAPISettings) (api_api.API, error) {
+func MakeLocalAPI_NoProject(settings handler_local.LocalAPISettings) (api_api.API, error) {
 	log.Debug("Local:API:: Building No-Project API")
 	bootstrapApi := api_builder.BuilderAPI{}
-	bootstrapApi.AddBuilder(handlers_local.New_LocalBuilder(settings))
+	bootstrapApi.AddBuilder(handler_local.New_LocalBuilder(settings))
 
 	// allow local project operations, which could be used to build a project
 	bootstrapApi.ActivateBuilder("local", *api_builder.New_Implementations([]string{"project"}), nil)
 
 	// Use null wrappers for those handlers that we don't have (to play safe)
-	bootstrapApi.AddBuilder(handlers_null.New_NullBuilder())
+	bootstrapApi.AddBuilder(handler_null.New_NullBuilder())
 	bootstrapApi.ActivateBuilder("null", *api_builder.New_Implementations([]string{"config", "seting", "command"}), nil)
 
 	return api_api.API(&bootstrapApi), nil

--- a/main/discover.go
+++ b/main/discover.go
@@ -5,7 +5,7 @@ import (
 	"os/user"
 	"path"
 
-	handlers_local "github.com/wunderkraut/radi-handlers/local"
+	handler_local "github.com/wunderkraut/radi-handlers/local"
 )
 
 const (
@@ -54,7 +54,7 @@ func userHomePath() string {
  * dependening on OS, determine if the user has any settings
  * if so, add a conf path for them.
  */
-func DiscoverUserPaths(settings *handlers_local.LocalAPISettings) error {
+func DiscoverUserPaths(settings *handler_local.LocalAPISettings) error {
 	var err error
 
 	homeDir := userHomePath()
@@ -90,7 +90,7 @@ func DiscoverUserPaths(settings *handlers_local.LocalAPISettings) error {
  * has the key configuration subfolder in it.  That path is marked as the
  * application root, and the subfolder is marked as a conf path
  */
-func DiscoverProjectPaths(settings *handlers_local.LocalAPISettings) error {
+func DiscoverProjectPaths(settings *handler_local.LocalAPISettings) error {
 	workingDir := settings.ExecPath
 	homeDir := userHomePath()
 
@@ -121,7 +121,7 @@ RootSearch:
  * Discover environment path for a specific environment
  *
  */
-func DiscoverEnvironmentPath(settings *handlers_local.LocalAPISettings, environment string) error {
+func DiscoverEnvironmentPath(settings *handler_local.LocalAPISettings, environment string) error {
 
 	/**
 	 * @TODO actually check to see if the path exists, so that we can warn if it doesn't?

--- a/main/main.go
+++ b/main/main.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	debug       bool                            = false                             // defualt to disable debugging output
-	workingDir  string                          = ""                                // can't use os.Cwd which returns multi-value
-	environment string                          = "local"                           // default to using a local environment
-	flags       []string                        = os.Args                           // store the cli args before they get used
+	debug       bool                           = false                            // defualt to disable debugging output
+	workingDir  string                         = ""                               // can't use os.Cwd which returns multi-value
+	environment string                         = "local"                          // default to using a local environment
+	flags       []string                       = os.Args                          // store the cli args before they get used
 	settings    handler_local.LocalAPISettings = handler_local.LocalAPISettings{} // just make sure that we have an object
-	ctx         context.Context                 = context.Background()              // this would allow us to terminate/timeout operations
+	ctx         context.Context                = context.Background()             // this would allow us to terminate/timeout operations
 )
 
 func init() {

--- a/main/main.go
+++ b/main/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
-
-	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/urfave/cli.v2"
@@ -12,7 +11,7 @@ import (
 	api_command "github.com/wunderkraut/radi-api/operation/command"
 	cli_local "github.com/wunderkraut/radi-cli/local"
 	"github.com/wunderkraut/radi-cli/version"
-	handlers_local "github.com/wunderkraut/radi-handlers/local"
+	handler_local "github.com/wunderkraut/radi-handlers/local"
 )
 
 var (
@@ -20,7 +19,7 @@ var (
 	workingDir  string                          = ""                                // can't use os.Cwd which returns multi-value
 	environment string                          = "local"                           // default to using a local environment
 	flags       []string                        = os.Args                           // store the cli args before they get used
-	settings    handlers_local.LocalAPISettings = handlers_local.LocalAPISettings{} // just make sure that we have an object
+	settings    handler_local.LocalAPISettings = handler_local.LocalAPISettings{} // just make sure that we have an object
 	ctx         context.Context                 = context.Background()              // this would allow us to terminate/timeout operations
 )
 

--- a/main/property.go
+++ b/main/property.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"context"
+	log "github.com/Sirupsen/logrus"
 	"gopkg.in/urfave/cli.v2"
 
 	api_operation "github.com/wunderkraut/radi-api/operation"

--- a/main/property.go
+++ b/main/property.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"golang.org/x/net/context"
+	"context"
 	"gopkg.in/urfave/cli.v2"
 
 	api_operation "github.com/wunderkraut/radi-api/operation"
@@ -83,7 +83,7 @@ func CliAssignPropertiesFromFlags(cliContext *cli.Context, props *api_operation.
 						prop.Set(io.Reader(os.Stdin))
 					}
 				}
-			case "golang.org/x/net/context.Context":
+			case "context.Context":
 				if cliContext.IsSet(key + ":duration") {
 					duration := cliContext.Duration(key + ".duration")
 					if duration > 0 {
@@ -162,7 +162,7 @@ func CliMakeFlagsFromProperties(props api_operation.Properties) []cli.Flag {
 					Value: "",
 					Usage: prop.Description(),
 				}))
-			case "golang.org/x/net/context.Context":
+			case "context.Context":
 				flags = append(flags, cli.Flag(&cli.DurationFlag{
 					Name:  prop.Id() + ":duration",
 					Usage: "Timeout in seconds. " + prop.Description(),

--- a/main/settings.go
+++ b/main/settings.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
-	handlers_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
-	handlers_local "github.com/wunderkraut/radi-handlers/local"
+	handler_bytesource "github.com/wunderkraut/radi-handlers/bytesource"
+	handler_local "github.com/wunderkraut/radi-handlers/local"
 )
 
 // Construct a LocalAPI by checking some paths for the current user.
-func MakeLocalAPISettings(workingDir string, ctx context.Context) handlers_local.LocalAPISettings {
+func MakeLocalAPISettings(workingDir string, ctx context.Context) handler_local.LocalAPISettings {
 	// create an initial empty settings
-	settings := handlers_local.LocalAPISettings{
-		BytesourceFileSettings: handlers_bytesource.BytesourceFileSettings{
+	settings := handler_local.LocalAPISettings{
+		BytesourceFileSettings: handler_bytesource.BytesourceFileSettings{
 			ExecPath:    workingDir,
-			ConfigPaths: &handlers_bytesource.Paths{},
+			ConfigPaths: &handler_bytesource.Paths{},
 		},
 		Context: ctx,
 	}


### PR DESCRIPTION
This patch allows the build process to work with newly refactored upstream radi libraries, which now have their own vendor folders.

This patch is not a complete version pin for this project, which will require full vendor submodules in this repository, but that work is ongoing.  This patch fixes and cleans the build.