### PR TITLE
Enable go get support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,31 @@ radi-cli
 --------------
 
 this is a cli implementation of the radi api, which gives some command line
-tools that can be used to run docker based applications from a project definition.
+tools that can be used to run docker based applications from a project
+definition.
 
-The project started off as a port of wundertools to a docker based system, and then
-ended up being an abstraction for a more generic project configuration.
+The project started off as a port of wundertools to a docker based system, and
+then ended up being an abstraction for a more generic project configuration.
 
-This CLI is not the only possible way to use the radi-api as a command line tool,
-but rather it is a first run at a typical radi-handler coordiantion for managing
-projects.
+This CLI is not the only possible way to use the radi-api as a command line
+tool, but rather it is a first run at a typical radi-handler coordiantion for
+managing projects.
+
 Some evidence of that:
-1. by default the upcloud handler is included, even though you may not use upcloud.
-2. by default the rancher handler is included, even though you may not use rancher.
+1. by default the upcloud and rancher handlers are included, even though you
+may not use them.
 
-While the radi-api takes some learning, it should be easy to fork this tool, and
-rewire the base handlers used to meet any corporate standard, including handlers
-from any source.
+While the radi-api takes some learning, it should be easy to fork this tool,
+and rewire the base handlers used to meet any corporate standard, including
+handlers from any source.
 
 ## Install the tool
 
 ### Requirements
 
-The tools is a go implementation, but it can be build without any go runtime, by
-building inside a container.
-This requires a working local docker implementation (as local volume binds are 
+The tools is a go implementation, but it can be build without any go runtime,
+by building inside a container.
+This requires a working local docker implementation (as local volume binds are
 used to return the binary.)
 
 If you want to fully build the binary yourself, there is a make system in place
@@ -32,38 +34,73 @@ that requires a go runtime
 
 ### Building inside a docker container
 
+#### 1. retrieve this source code via git.
+
 ```
-$/> ./build.sh
+$/> git clone https://github.com/wunderkraut/radi-cli
+
 ```
 
-This produces a binary `radi`, which you can put wherever you want to put such 
+#### 2. run the build script
+
+in the repository root (`cd radi-cli`) run the build script
+
+```
+$/> sh ./build.sh
+```
+
+This produces a binary `radi`, which you can put wherever you want to put such
 binaries.  If there is consensus on install paths, we can make an installer
 
-### Use the make
+### Manually building
 
-Run 
+When manually building the source code, you will need a working `go`
+environemnt and the source checked out inside the GOPATH.
+
+* The project uses a vendor folder, so **go 1.6 is required as a minimum**.
+
+#### Using go get
+
+Try simple running:
 
 ```
+$/> go get -u github.com/wunderkraut/radi-cli/radi
+```
+
+if this works, you should have a radi binary executable in the `$GOPATH/bin`
+folder.
+
+#### Manually check out the source
+
+##### 1. use git to clone the repository into the appropriate path
+
+```
+$/> git clone https://github.com/wunderkraut/radi-cli "${GOPATH}/src/github.com/wunderkraut/radi-cli"
+```
+
+##### 2. run the build script in the radi-cli root
+
+```
+$/> cd "${GOPATH}/src/github.com/wunderkraut/radi-cli"
 $/> make all
 ```
 
 Which will pull dependencies and product a binary locally.  It also installs
 the binary to a reasonable path.
 
-
 ## Using the CLI
 
-once the cli is installed, it can be used withing the scope of any project
-that has a .radi folder, which demarks the root of the project (like git)
+once the cli is installed, it can be used withing the scope of any project that
+has a .radi folder, which demarks the root of the project (like git)
 
 ### general usage
 
 
 #### First steps
 
-running `radi help` should list all operations.  
+running `radi help` should list all operations.
 
-running `radi help <operation>` should give more information about each 
+running `radi help <operation>` should give more information about each
 operation and what parameters it expects.
 
 #### Global flags
@@ -72,9 +109,9 @@ if you run radi with --debug, you will get verbose output.
 
 #### Typical operations
 
-There are no base or default operations. All operations are provided by
-the handlers, but radi will try to at least include the init/create
-commands even if no other operations are defined.
+There are no base or default operations. All operations are provided by the
+handlers, but radi will try to at least include the init/create commands even
+if no other operations are defined.
 
 Typically, a local project will include some orchestration operations:
 
@@ -86,8 +123,8 @@ And a number of custom commands for the project as defined in
 
 ### enabling radi in an existing folder
 
-If you have a project which you would like to use as a radi project, you
-can manually add a .radi folder to the root.
+If you have a project which you would like to use as a radi project, you can
+manually add a .radi folder to the root.
 
 An empty .radi folder will produce some errors, but it works.
 
@@ -95,7 +132,7 @@ An empty .radi folder will produce some errors, but it works.
 
 #### init
 
-You can intialize any folder with the command 
+You can intialize any folder with the command
 
 ```
 $/> radi local.project.init
@@ -106,15 +143,15 @@ which will add some .radi files to your project
 #### create
 
 Creation adds files to your project using yml templates, which can be easily
-shared, as gists, or locally available files, or raw git repo files.  Any 
-http url can be used.
+shared, as gists, or locally available files, or raw git repo files.  Any http
+url can be used.
 
 The templates contain sequential instructions for building a project.
 
 ##### generate
 
-The command `radi local.project.generate` attempts to build a template from
-the current project, that can be used with the create command.
+The command `radi local.project.generate` attempts to build a template from the
+current project, that can be used with the create command.
 
 ## Radi usage
 
@@ -124,8 +161,8 @@ The tools are an implementation that uses the radi-api, and a number of
 radi-handlers to build a cli with a set of operations that can manage a local
 project.
 
-The API relied on to define handler behaviour, but also the API provides an
-API builder approach for pulling together handlers and elements from different
+The API relied on to define handler behaviour, but also the API provides an API
+builder approach for pulling together handlers and elements from different
 sources.
 
 ### radi-handlers
@@ -133,16 +170,16 @@ sources.
 From the API perspective, the CLI relies heavily on the `local` handler, which
 uses local configuration files to define an active project.
 
-Additionally, currently the handlers for upcloud, and rancher are included
-as they are the primary tools that we are using to manager servers and 
+Additionally, currently the handlers for upcloud, and rancher are included as
+they are the primary tools that we are using to manager servers and
 orchestration outside of local operations.
 
-As with all radi-api implementations, operations are provided primarily by
-the included handlers, when they are activated.
+As with all radi-api implementations, operations are provided primarily by the
+included handlers, when they are activated.
 
 ### Conversion of handler operations to cli behaviour
 
 Currently the cli tool takes the simplest approach to implementing handler
-operations by literally exposing any operation not marked as "internal" to
-the cli.  Any operation parameter that can be interpreted is made available
-to the CLI
+operations by literally exposing any operation not marked as "internal" to the
+cli.  Any operation parameter that can be interpreted is made available to the
+CLI.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,19 @@ Try simple running:
 $/> go get -u github.com/wunderkraut/radi-cli/radi
 ```
 
-if this works, you should have a radi binary executable in the `$GOPATH/bin`
-folder.
+If this works, you should have a radi binary executable in the `$GOPATH/bin`
+folder. Unfortunately go-get doesn't use the packaged libraries vendor git 
+submodules properly yet, which means that dependency versioning isn't strict.
+
+You should then manually rebuild the binary using:
+
+```
+$/> cd "${GOPATH}/src/github.com/wunderkraut/radi-cli"
+$/> make all
+
+```
+
+This will result in a properly build binary.
 
 #### Manually check out the source
 

--- a/build.sh
+++ b/build.sh
@@ -29,12 +29,13 @@ This will build the radi-cli as a 'radi' binary for '$GOOS-$GOARCH'.
 # some sanity stuff, to prevent docker related permissions issues
 mkdir -p "${RADI_BUILD_PATH}"
 mkdir -p ".git/modules/vendor"
+chmod u+x Makefile
 
 # Run the build inside a container
 #
 #  - volumify the submodule changes
 #  - build in a valid gopath to get active vendor dependencies
-#  - pass in env variables for environment contril
+#  - pass in env variables for environment control
 docker run --rm -ti \
 	-v "${EXEC_PATH}:/go/src/${INTERNAL_LIBRARY_PATH}" \
 	-v "/go/src/${INTERNAL_LIBRARY_PATH}/.git/modules/vendor" \

--- a/build/binary
+++ b/build/binary
@@ -9,8 +9,6 @@
 # Get rid of existing binary
 rm -f "${RADI_BUILD_BINARY_PATH}"
 
-go generate
-
 BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
 GITCOMMIT=$(git rev-parse --short HEAD)
 
@@ -24,4 +22,4 @@ go build \
    -v \
    -ldflags="-w -X ${RADI_PKG}/version.GITCOMMIT=${GITCOMMIT} -X ${RADI_PKG}/version.BUILDTIME=${BUILDTIME} -X ${RADI_PKG}/version.SHOWWARNING=${SHOWWARNING}" \
    -o "${RADI_BUILD_BINARY_PATH}" \
-   ./main
+   ./radi

--- a/radi/command.go
+++ b/radi/command.go
@@ -1,4 +1,4 @@
-package main
+package radi
 
 import (
 	"errors"

--- a/radi/command.go
+++ b/radi/command.go
@@ -1,4 +1,4 @@
-package radi
+package main
 
 import (
 	"errors"

--- a/radi/discover.go
+++ b/radi/discover.go
@@ -1,4 +1,4 @@
-package main
+package radi
 
 import (
 	"os"

--- a/radi/discover.go
+++ b/radi/discover.go
@@ -1,4 +1,4 @@
-package radi
+package main
 
 import (
 	"os"

--- a/radi/main.go
+++ b/radi/main.go
@@ -1,4 +1,4 @@
-package radi
+package main
 
 import (
 	"context"

--- a/radi/main.go
+++ b/radi/main.go
@@ -1,4 +1,4 @@
-package main
+package radi
 
 import (
 	"context"

--- a/radi/operation.go
+++ b/radi/operation.go
@@ -1,4 +1,4 @@
-package main
+package radi
 
 import (
 	"errors"

--- a/radi/operation.go
+++ b/radi/operation.go
@@ -1,4 +1,4 @@
-package radi
+package main
 
 import (
 	"errors"

--- a/radi/property.go
+++ b/radi/property.go
@@ -1,4 +1,4 @@
-package main
+package radi
 
 import (
 	"io"

--- a/radi/property.go
+++ b/radi/property.go
@@ -1,4 +1,4 @@
-package radi
+package main
 
 import (
 	"io"

--- a/radi/settings.go
+++ b/radi/settings.go
@@ -1,4 +1,4 @@
-package radi
+package main
 
 import (
 	"context"

--- a/radi/settings.go
+++ b/radi/settings.go
@@ -1,4 +1,4 @@
-package main
+package radi
 
 import (
 	"context"


### PR DESCRIPTION
This is a patch that slightly refactors the code to allow it to work better with standard `go get` functionality.

This should help solve #24 

Note that when using `go get` it may be that the pinned dependencies don't work, but this needs to be in master before we can really test that.
The best approach for us now is to change the docs to recommend retrieving the code using `go get` and then building manually in the `${GOPATH}/src/github.com/wunderkraut/radi-cli` path.

This fixes local manual builds by putting the codebase into the GOPATH, meaning that the vendor paths should work.