### PR TITLE
Default to local user

### DIFF
--- a/radi/discover.go
+++ b/radi/discover.go
@@ -47,6 +47,22 @@ func userHomePath() string {
 }
 
 /**
+ * Discover who is the current user
+ *
+ * Used in some security cases.
+ */
+func DiscoverCurrentUser(settings *handler_local.LocalAPISettings) error {
+
+	if user, err := user.Current(); err == nil {
+		settings.User = *user
+		return err
+	} else {
+		return err
+	}
+
+}
+
+/**
  * Discover some user paths
  *
  * @NOTE we have to play some games for different OSes here

--- a/radi/main.go
+++ b/radi/main.go
@@ -121,6 +121,9 @@ func main() {
 	workingDir, _ = os.Getwd()
 	settings = MakeLocalAPISettings(workingDir, ctx)
 
+	// Discover the current User
+	DiscoverCurrentUser(&settings)
+
 	// Discover paths for the user like ~ and ~/.config/wundertools
 	DiscoverUserPaths(&settings)
 	DiscoverProjectPaths(&settings)

--- a/radi/operation.go
+++ b/radi/operation.go
@@ -108,9 +108,19 @@ func (opWrapper *CliOperationWrapper) Exec(cliContext *cli.Context) error {
 					user := prop.Get().(api_security.SecurityUser)
 					fields[key] = user.Id()
 				}
+			} else {
+				// some intenal props can get output regardless
+				switch prop.Id() {
+				case "security.user":
+					user := prop.Get().(api_security.SecurityUser)
+					fields[key] = user.Id()
+				case "security.authorization.success":
+					fields[key] = prop.Get().(bool)
+				}
 			}
 		}
 
+		logger = logger.WithFields(log.Fields(fields))
 		logger.Info("Operation completed.")
 		return nil
 	} else {


### PR DESCRIPTION
The local cli builder now adds the os/user.CurrentUser() to the local settings, where it can be used as a default SecurityUser implementation, if no explicity user configurations can be found.

This depends on https://github.com/wunderkraut/radi-api/pull/8