### PR TITLE
make the local api builder check the project build validity

### DIFF
--- a/local/api.go
+++ b/local/api.go
@@ -56,6 +56,17 @@ func MakeLocalAPI(settings handler_local.LocalAPISettings) (api_api.API, error) 
 
 		ActivateConfigBuilders(localProject, settings, bootstrapConfigWrapper)
 
+		validateResult := localProject.Validate()
+		<-validateResult.Finished()
+		if !validateResult.Success() {
+			errs := validateResult.Errors()
+			if len(errs) > 0 {
+				err = errs[len(errs)-1]
+			} else {
+				err = errors.New("Secure local builder could not build a valid project")
+			}
+		}
+
 		return localProject.API(), err
 	}
 


### PR DESCRIPTION
This patch adds a small amount of code to the cli routines that build the project, to use the new Project.Validate() method, and output some warnings if the project is not valid.