### PR TITLE
the build.sh now uses and selinux safe local volume bind

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ chmod u+x Makefile
 #  - build in a valid gopath to get active vendor dependencies
 #  - pass in env variables for environment control
 docker run --rm -ti \
-	-v "${EXEC_PATH}:/go/src/${INTERNAL_LIBRARY_PATH}" \
+	-v "${EXEC_PATH}:/go/src/${INTERNAL_LIBRARY_PATH}:Z" \
 	-v "/go/src/${INTERNAL_LIBRARY_PATH}/.git/modules/vendor" \
 	-v "/go/src/${INTERNAL_LIBRARY_PATH}/vendor" \
 	-e "GOOS=${GOOS}" \


### PR DESCRIPTION
This patch makes the build use permissive volume binds when building.

This should fix #24 

This type of fix broke some functionality in one of the project wrappers, but I suspect that it was rejected by the library.  This should be tested by someone on Fedora, and someone not on Fedora.